### PR TITLE
refactor: use cast() to cast ptr types

### DIFF
--- a/src/platforms/darwin.rs
+++ b/src/platforms/darwin.rs
@@ -52,7 +52,7 @@ pub fn listxattr<P: AsRef<Path>>(
     let res = unsafe {
         libc::listxattr(
             path.as_ptr(),
-            buffer.as_ptr() as *mut libc::c_char,
+            buffer.as_mut_ptr().cast(),
             buffer.capacity(),
             options,
         )
@@ -91,7 +91,7 @@ pub fn flistxattr(fd: RawFd, options: Options) -> Result<Vec<OsString>> {
     let res = unsafe {
         libc::flistxattr(
             fd,
-            buffer.as_ptr() as *mut libc::c_char,
+            buffer.as_mut_ptr().cast(),
             buffer.capacity(),
             options,
         )
@@ -139,7 +139,7 @@ where
     let buffer_size = match unsafe {
         libc::getxattr(
             path.as_ptr(),
-            name.as_ptr() as *mut libc::c_char,
+            name.as_ptr().cast(),
             null_mut(),
             0,
             position,
@@ -155,9 +155,9 @@ where
 
     let res = unsafe {
         libc::getxattr(
-            path.as_ptr() as *mut libc::c_char,
-            name.as_ptr() as *mut libc::c_char,
-            buffer.as_ptr() as *mut libc::c_void,
+            path.as_ptr(),
+            name.as_ptr(),
+            buffer.as_mut_ptr().cast(),
             buffer_size as usize,
             position,
             options,
@@ -195,7 +195,7 @@ pub fn fgetxattr<S: AsRef<OsStr>>(
     let buffer_size = match unsafe {
         libc::fgetxattr(
             fd,
-            name.as_ptr() as *mut libc::c_char,
+            name.as_ptr(),
             null_mut(),
             0,
             position,
@@ -212,8 +212,8 @@ pub fn fgetxattr<S: AsRef<OsStr>>(
     let res = unsafe {
         libc::fgetxattr(
             fd,
-            name.as_ptr() as *mut libc::c_char,
-            buffer.as_ptr() as *mut libc::c_void,
+            name.as_ptr(),
+            buffer.as_mut_ptr().cast(),
             buffer_size as usize,
             position,
             options,
@@ -251,7 +251,7 @@ where
 
     let res = unsafe {
         libc::removexattr(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             name.as_ptr(),
             options,
         )
@@ -312,13 +312,13 @@ where
         Ok(name) => name,
         _ => return Err(Errno(libc::EINVAL)),
     };
-    let value_ptr = value.as_ref().as_ptr() as *mut libc::c_void;
+    let value_ptr = value.as_ref().as_ptr().cast();
     let value_len = value.as_ref().len();
     let options = options.bits();
 
     let res = unsafe {
         libc::setxattr(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             name.as_ptr(),
             value_ptr,
             value_len,
@@ -353,7 +353,7 @@ where
         Ok(name) => name,
         _ => return Err(Errno(libc::EINVAL)),
     };
-    let value_ptr = value.as_ref().as_ptr() as *mut libc::c_void;
+    let value_ptr = value.as_ref().as_ptr().cast();
     let value_len = value.as_ref().len();
     let options = options.bits();
 

--- a/src/platforms/darwin.rs
+++ b/src/platforms/darwin.rs
@@ -193,14 +193,7 @@ pub fn fgetxattr<S: AsRef<OsStr>>(
 
     // query the buffer size
     let buffer_size = match unsafe {
-        libc::fgetxattr(
-            fd,
-            name.as_ptr(),
-            null_mut(),
-            0,
-            position,
-            options,
-        )
+        libc::fgetxattr(fd, name.as_ptr(), null_mut(), 0, position, options)
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
@@ -249,13 +242,8 @@ where
     };
     let options = options.bits();
 
-    let res = unsafe {
-        libc::removexattr(
-            path.as_ptr(),
-            name.as_ptr(),
-            options,
-        )
-    };
+    let res =
+        unsafe { libc::removexattr(path.as_ptr(), name.as_ptr(), options) };
 
     match res {
         -1 => Err(errno()),

--- a/src/platforms/freebsd.rs
+++ b/src/platforms/freebsd.rs
@@ -35,13 +35,8 @@ pub fn extattr_delete_fd<S: AsRef<OsStr>>(
         _ => return Err(Errno(libc::EINVAL)),
     };
 
-    let res = unsafe {
-        libc::extattr_delete_fd(
-            fd,
-            namespace,
-            attr_name.as_ptr(),
-        )
-    };
+    let res =
+        unsafe { libc::extattr_delete_fd(fd, namespace, attr_name.as_ptr()) };
 
     match res {
         -1 => Err(errno()),
@@ -59,9 +54,9 @@ pub fn extattr_delete_file<P, S>(
     attrnamespace: AttrNamespace,
     attrname: S,
 ) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -74,11 +69,7 @@ pub fn extattr_delete_file<P, S>(
     };
 
     let res = unsafe {
-        libc::extattr_delete_file(
-            path.as_ptr(),
-            namespace,
-            attr_name.as_ptr(),
-        )
+        libc::extattr_delete_file(path.as_ptr(), namespace, attr_name.as_ptr())
     };
 
     match res {
@@ -97,9 +88,9 @@ pub fn extattr_delete_link<P, S>(
     attrnamespace: AttrNamespace,
     attrname: S,
 ) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -112,11 +103,7 @@ pub fn extattr_delete_link<P, S>(
     };
 
     let res = unsafe {
-        libc::extattr_delete_link(
-            path.as_ptr(),
-            namespace,
-            attr_name.as_ptr(),
-        )
+        libc::extattr_delete_link(path.as_ptr(), namespace, attr_name.as_ptr())
     };
 
     match res {
@@ -167,13 +154,12 @@ pub fn extattr_list_fd(
     let namespace = attrnamespace as libc::c_int;
 
     // query the buffer size
-    let buffer_size = match unsafe {
-        libc::extattr_list_fd(fd, namespace, null_mut(), 0)
-    } {
-        -1 => return Err(errno()),
-        0 => return Ok(Vec::new()),
-        size => size,
-    };
+    let buffer_size =
+        match unsafe { libc::extattr_list_fd(fd, namespace, null_mut(), 0) } {
+            -1 => return Err(errno()),
+            0 => return Ok(Vec::new()),
+            size => size,
+        };
 
     let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
 
@@ -203,8 +189,8 @@ pub fn extattr_list_file<P>(
     path: P,
     attrnamespace: AttrNamespace,
 ) -> Result<Vec<OsString>>
-    where
-        P: AsRef<Path>,
+where
+    P: AsRef<Path>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -214,12 +200,7 @@ pub fn extattr_list_file<P>(
 
     // query the buffer size
     let buffer_size = match unsafe {
-        libc::extattr_list_file(
-            path.as_ptr(),
-            namespace,
-            null_mut(),
-            0,
-        )
+        libc::extattr_list_file(path.as_ptr(), namespace, null_mut(), 0)
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
@@ -255,8 +236,8 @@ pub fn extattr_list_link<P>(
     path: P,
     attrnamespace: AttrNamespace,
 ) -> Result<Vec<OsString>>
-    where
-        P: AsRef<Path>,
+where
+    P: AsRef<Path>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -266,12 +247,7 @@ pub fn extattr_list_link<P>(
 
     // query the buffer size
     let buffer_size = match unsafe {
-        libc::extattr_list_link(
-            path.as_ptr(),
-            namespace,
-            null_mut(),
-            0,
-        )
+        libc::extattr_list_link(path.as_ptr(), namespace, null_mut(), 0)
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
@@ -315,13 +291,7 @@ pub fn extattr_get_fd<S: AsRef<OsStr>>(
 
     // query buffer size
     let buffer_size = match unsafe {
-        libc::extattr_get_fd(
-            fd,
-            namespace,
-            attrname.as_ptr(),
-            null_mut(),
-            0,
-        )
+        libc::extattr_get_fd(fd, namespace, attrname.as_ptr(), null_mut(), 0)
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
@@ -357,9 +327,9 @@ pub fn extattr_get_file<P, S>(
     attrnamespace: AttrNamespace,
     attrname: S,
 ) -> Result<Vec<u8>>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -416,9 +386,9 @@ pub fn extattr_get_link<P, S>(
     attrnamespace: AttrNamespace,
     attrname: S,
 ) -> Result<Vec<u8>>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -475,9 +445,9 @@ pub fn extattr_set_fd<S, B>(
     attrname: S,
     data: B,
 ) -> Result<()>
-    where
-        S: AsRef<OsStr>,
-        B: AsRef<[u8]>,
+where
+    S: AsRef<OsStr>,
+    B: AsRef<[u8]>,
 {
     let namespace = attrnamespace as libc::c_int;
     let attrname = match CString::new(attrname.as_ref().as_bytes()) {
@@ -514,10 +484,10 @@ pub fn extattr_set_file<P, S, B>(
     attrname: S,
     data: B,
 ) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
-        B: AsRef<[u8]>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
+    B: AsRef<[u8]>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -558,10 +528,10 @@ pub fn extattr_set_link<P, S, B>(
     attrname: S,
     data: B,
 ) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
-        B: AsRef<[u8]>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
+    B: AsRef<[u8]>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,

--- a/src/platforms/freebsd.rs
+++ b/src/platforms/freebsd.rs
@@ -39,7 +39,7 @@ pub fn extattr_delete_fd<S: AsRef<OsStr>>(
         libc::extattr_delete_fd(
             fd,
             namespace,
-            attr_name.as_ptr() as *mut libc::c_char,
+            attr_name.as_ptr(),
         )
     };
 
@@ -59,9 +59,9 @@ pub fn extattr_delete_file<P, S>(
     attrnamespace: AttrNamespace,
     attrname: S,
 ) -> Result<()>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -75,9 +75,9 @@ where
 
     let res = unsafe {
         libc::extattr_delete_file(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            attr_name.as_ptr() as *mut libc::c_char,
+            attr_name.as_ptr(),
         )
     };
 
@@ -97,9 +97,9 @@ pub fn extattr_delete_link<P, S>(
     attrnamespace: AttrNamespace,
     attrname: S,
 ) -> Result<()>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -113,9 +113,9 @@ where
 
     let res = unsafe {
         libc::extattr_delete_link(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            attr_name.as_ptr() as *mut libc::c_char,
+            attr_name.as_ptr(),
         )
     };
 
@@ -168,20 +168,20 @@ pub fn extattr_list_fd(
 
     // query the buffer size
     let buffer_size = match unsafe {
-        libc::extattr_list_fd(fd, namespace, null_mut() as *mut libc::c_void, 0)
+        libc::extattr_list_fd(fd, namespace, null_mut(), 0)
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
         size => size,
     };
 
-    let mut buffer = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
 
     let res = unsafe {
         libc::extattr_list_fd(
             fd,
             namespace,
-            buffer.as_ptr() as *mut libc::c_void,
+            buffer.as_mut_ptr().cast(),
             buffer_size as libc::size_t,
         )
     };
@@ -203,8 +203,8 @@ pub fn extattr_list_file<P>(
     path: P,
     attrnamespace: AttrNamespace,
 ) -> Result<Vec<OsString>>
-where
-    P: AsRef<Path>,
+    where
+        P: AsRef<Path>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -215,9 +215,9 @@ where
     // query the buffer size
     let buffer_size = match unsafe {
         libc::extattr_list_file(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            null_mut() as *mut libc::c_void,
+            null_mut(),
             0,
         )
     } {
@@ -226,13 +226,13 @@ where
         size => size,
     };
 
-    let mut buffer = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
 
     let res = unsafe {
         libc::extattr_list_file(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            buffer.as_ptr() as *mut libc::c_void,
+            buffer.as_mut_ptr().cast(),
             buffer_size as libc::size_t,
         )
     };
@@ -255,8 +255,8 @@ pub fn extattr_list_link<P>(
     path: P,
     attrnamespace: AttrNamespace,
 ) -> Result<Vec<OsString>>
-where
-    P: AsRef<Path>,
+    where
+        P: AsRef<Path>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -267,9 +267,9 @@ where
     // query the buffer size
     let buffer_size = match unsafe {
         libc::extattr_list_link(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            null_mut() as *mut libc::c_void,
+            null_mut(),
             0,
         )
     } {
@@ -278,13 +278,13 @@ where
         size => size,
     };
 
-    let mut buffer = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
 
     let res = unsafe {
         libc::extattr_list_link(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            buffer.as_ptr() as *mut libc::c_void,
+            buffer.as_mut_ptr().cast(),
             buffer_size as libc::size_t,
         )
     };
@@ -318,8 +318,8 @@ pub fn extattr_get_fd<S: AsRef<OsStr>>(
         libc::extattr_get_fd(
             fd,
             namespace,
-            attrname.as_ptr() as *mut libc::c_char,
-            null_mut() as *mut libc::c_void,
+            attrname.as_ptr(),
+            null_mut(),
             0,
         )
     } {
@@ -327,14 +327,14 @@ pub fn extattr_get_fd<S: AsRef<OsStr>>(
         0 => return Ok(Vec::new()),
         size => size,
     };
-    let mut buffer = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
 
     let res = unsafe {
         libc::extattr_get_fd(
             fd,
             namespace,
-            attrname.as_ptr() as *mut libc::c_char,
-            null_mut() as *mut libc::c_void,
+            attrname.as_ptr(),
+            buffer.as_mut_ptr().cast(),
             0,
         )
     };
@@ -357,9 +357,9 @@ pub fn extattr_get_file<P, S>(
     attrnamespace: AttrNamespace,
     attrname: S,
 ) -> Result<Vec<u8>>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -374,10 +374,10 @@ where
     // query buffer size
     let buffer_size = match unsafe {
         libc::extattr_get_file(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            attrname.as_ptr() as *mut libc::c_char,
-            null_mut() as *mut libc::c_void,
+            attrname.as_ptr(),
+            null_mut(),
             0,
         )
     } {
@@ -385,14 +385,14 @@ where
         0 => return Ok(Vec::new()),
         size => size,
     };
-    let mut buffer = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
 
     let res = unsafe {
         libc::extattr_get_file(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            attrname.as_ptr() as *mut libc::c_char,
-            null_mut() as *mut libc::c_void,
+            attrname.as_ptr(),
+            buffer.as_mut_ptr().cast(),
             0,
         )
     };
@@ -416,9 +416,9 @@ pub fn extattr_get_link<P, S>(
     attrnamespace: AttrNamespace,
     attrname: S,
 ) -> Result<Vec<u8>>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(p) => p,
@@ -433,10 +433,10 @@ where
     // query buffer size
     let buffer_size = match unsafe {
         libc::extattr_get_link(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            attrname.as_ptr() as *mut libc::c_char,
-            null_mut() as *mut libc::c_void,
+            attrname.as_ptr(),
+            null_mut(),
             0,
         )
     } {
@@ -444,14 +444,14 @@ where
         0 => return Ok(Vec::new()),
         size => size,
     };
-    let mut buffer = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
 
     let res = unsafe {
         libc::extattr_get_link(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            attrname.as_ptr() as *mut libc::c_char,
-            null_mut() as *mut libc::c_void,
+            attrname.as_ptr(),
+            buffer.as_mut_ptr().cast(),
             0,
         )
     };
@@ -475,23 +475,23 @@ pub fn extattr_set_fd<S, B>(
     attrname: S,
     data: B,
 ) -> Result<()>
-where
-    S: AsRef<OsStr>,
-    B: AsRef<[u8]>,
+    where
+        S: AsRef<OsStr>,
+        B: AsRef<[u8]>,
 {
     let namespace = attrnamespace as libc::c_int;
     let attrname = match CString::new(attrname.as_ref().as_bytes()) {
         Ok(n) => n,
         _ => return Err(Errno(libc::EINVAL)),
     };
-    let data_ptr = data.as_ref().as_ptr() as *mut libc::c_void;
+    let data_ptr = data.as_ref().as_ptr().cast();
     let data_len = data.as_ref().len();
 
     let res = unsafe {
         libc::extattr_set_fd(
             fd,
             namespace,
-            attrname.as_ptr() as *mut libc::c_char,
+            attrname.as_ptr(),
             data_ptr,
             data_len,
         )
@@ -514,10 +514,10 @@ pub fn extattr_set_file<P, S, B>(
     attrname: S,
     data: B,
 ) -> Result<()>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
-    B: AsRef<[u8]>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
+        B: AsRef<[u8]>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -528,14 +528,14 @@ where
         Ok(n) => n,
         _ => return Err(Errno(libc::EINVAL)),
     };
-    let data_ptr = data.as_ref().as_ptr() as *mut libc::c_void;
+    let data_ptr = data.as_ref().as_ptr().cast();
     let data_len = data.as_ref().len();
 
     let res = unsafe {
         libc::extattr_set_file(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            attrname.as_ptr() as *mut libc::c_char,
+            attrname.as_ptr(),
             data_ptr,
             data_len,
         )
@@ -558,10 +558,10 @@ pub fn extattr_set_link<P, S, B>(
     attrname: S,
     data: B,
 ) -> Result<()>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
-    B: AsRef<[u8]>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
+        B: AsRef<[u8]>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -572,14 +572,14 @@ where
         Ok(n) => n,
         _ => return Err(Errno(libc::EINVAL)),
     };
-    let data_ptr = data.as_ref().as_ptr() as *mut libc::c_void;
+    let data_ptr = data.as_ref().as_ptr().cast();
     let data_len = data.as_ref().len();
 
     let res = unsafe {
         libc::extattr_set_link(
-            path.as_ptr() as *mut libc::c_char,
+            path.as_ptr(),
             namespace,
-            attrname.as_ptr() as *mut libc::c_char,
+            attrname.as_ptr(),
             data_ptr,
             data_len,
         )
@@ -603,7 +603,7 @@ mod test {
         assert_eq!(
             vec![
                 OsStr::new("attrname").to_owned(),
-                OsStr::new("anotherattrname").to_owned()
+                OsStr::new("anotherattrname").to_owned(),
             ],
             ret
         );

--- a/src/platforms/linux_and_android.rs
+++ b/src/platforms/linux_and_android.rs
@@ -44,7 +44,7 @@ pub fn listxattr<P: AsRef<Path>>(path: P) -> Result<Vec<OsString>> {
     let res = unsafe {
         libc::listxattr(
             path.as_ptr(),
-            buffer.as_ptr() as *mut libc::c_char,
+            buffer.as_mut_ptr().cast(),
             buffer.capacity(),
         )
     };
@@ -85,7 +85,7 @@ pub fn llistxattr<P: AsRef<Path>>(path: P) -> Result<Vec<OsString>> {
     let res = unsafe {
         libc::llistxattr(
             path.as_ptr(),
-            buffer.as_ptr() as *mut libc::c_char,
+            buffer.as_mut_ptr().cast(),
             buffer.capacity(),
         )
     };
@@ -119,7 +119,7 @@ pub fn flistxattr(fd: RawFd) -> Result<Vec<OsString>> {
     let res = unsafe {
         libc::flistxattr(
             fd,
-            buffer.as_ptr() as *mut libc::c_char,
+            buffer.as_mut_ptr().cast(),
             buffer.capacity(),
         )
     };
@@ -143,9 +143,9 @@ pub fn flistxattr(fd: RawFd) -> Result<Vec<OsString>> {
 ///
 /// For more information, see [getxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
 pub fn getxattr<P, S>(path: P, name: S) -> Result<Vec<u8>>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
 {
     let name = match CString::new(name.as_ref().as_bytes()) {
         Ok(n) => n,
@@ -171,7 +171,7 @@ where
         libc::getxattr(
             path.as_ptr(),
             name.as_ptr(),
-            buffer.as_ptr() as *mut libc::c_void,
+            buffer.as_mut_ptr().cast(),
             buffer_size as usize,
         )
     };
@@ -191,9 +191,9 @@ where
 ///
 /// For more information, see [lgetxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
 pub fn lgetxattr<P, S>(path: P, name: S) -> Result<Vec<u8>>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
 {
     let name = match CString::new(name.as_ref().as_bytes()) {
         Ok(n) => n,
@@ -219,7 +219,7 @@ where
         libc::lgetxattr(
             path.as_ptr(),
             name.as_ptr(),
-            buffer.as_ptr() as *mut libc::c_void,
+            buffer.as_mut_ptr().cast(),
             buffer_size as usize,
         )
     };
@@ -239,8 +239,8 @@ where
 ///
 /// For more information, see [fgetxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
 pub fn fgetxattr<S>(fd: RawFd, name: S) -> Result<Vec<u8>>
-where
-    S: AsRef<OsStr>,
+    where
+        S: AsRef<OsStr>,
 {
     let name = match CString::new(name.as_ref().as_bytes()) {
         Ok(name) => name,
@@ -261,7 +261,7 @@ where
         libc::fgetxattr(
             fd,
             name.as_ptr(),
-            buffer.as_ptr() as *mut libc::c_void,
+            buffer.as_mut_ptr().cast(),
             buffer_size as usize,
         )
     };
@@ -281,9 +281,9 @@ where
 ///
 /// For more information, see [removexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
 pub fn removexattr<P, S>(path: P, name: S) -> Result<()>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -308,9 +308,9 @@ where
 ///
 /// For more information, see [lremovexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
 pub fn lremovexattr<P, S>(path: P, name: S) -> Result<()>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -334,8 +334,8 @@ where
 ///
 /// For more information, see [fremovexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
 pub fn fremovexattr<S>(fd: RawFd, name: S) -> Result<()>
-where
-    S: AsRef<OsStr>,
+    where
+        S: AsRef<OsStr>,
 {
     let name = match CString::new(name.as_ref().as_bytes()) {
         Ok(name) => name,
@@ -355,10 +355,10 @@ where
 ///
 /// For more information, see [setxattr(2)](https://man7.org/linux/man-pages/man2/lsetxattr.2.html)
 pub fn setxattr<P, S, B>(path: P, name: S, value: B, flags: Flags) -> Result<()>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
-    B: AsRef<[u8]>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
+        B: AsRef<[u8]>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -369,7 +369,7 @@ where
         _ => return Err(Errno(libc::EINVAL)),
     };
 
-    let value_ptr = value.as_ref().as_ptr() as *mut libc::c_void;
+    let value_ptr = value.as_ref().as_ptr().cast();
     let value_len = value.as_ref().len();
 
     let res = unsafe {
@@ -399,10 +399,10 @@ pub fn lsetxattr<P, S, B>(
     value: B,
     flags: Flags,
 ) -> Result<()>
-where
-    P: AsRef<Path>,
-    S: AsRef<OsStr>,
-    B: AsRef<[u8]>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
+        B: AsRef<[u8]>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -413,7 +413,7 @@ where
         _ => return Err(Errno(libc::EINVAL)),
     };
 
-    let value_ptr = value.as_ref().as_ptr() as *mut libc::c_void;
+    let value_ptr = value.as_ref().as_ptr().cast();
     let value_len = value.as_ref().len();
 
     let res = unsafe {
@@ -437,16 +437,16 @@ where
 ///
 /// For more information, see [fsetxattr(2)](https://man7.org/linux/man-pages/man2/lsetxattr.2.html)
 pub fn fsetxattr<S, B>(fd: RawFd, name: S, value: B, flags: Flags) -> Result<()>
-where
-    S: AsRef<OsStr>,
-    B: AsRef<[u8]>,
+    where
+        S: AsRef<OsStr>,
+        B: AsRef<[u8]>,
 {
     let name = match CString::new(name.as_ref().as_bytes()) {
         Ok(name) => name,
         _ => return Err(Errno(libc::EINVAL)),
     };
 
-    let value_ptr = value.as_ref().as_ptr() as *mut libc::c_void;
+    let value_ptr = value.as_ref().as_ptr().cast();
     let value_len = value.as_ref().len();
 
     let res = unsafe {

--- a/src/platforms/linux_and_android.rs
+++ b/src/platforms/linux_and_android.rs
@@ -117,11 +117,7 @@ pub fn flistxattr(fd: RawFd) -> Result<Vec<OsString>> {
 
     let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
     let res = unsafe {
-        libc::flistxattr(
-            fd,
-            buffer.as_mut_ptr().cast(),
-            buffer.capacity(),
-        )
+        libc::flistxattr(fd, buffer.as_mut_ptr().cast(), buffer.capacity())
     };
 
     match res {
@@ -143,9 +139,9 @@ pub fn flistxattr(fd: RawFd) -> Result<Vec<OsString>> {
 ///
 /// For more information, see [getxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
 pub fn getxattr<P, S>(path: P, name: S) -> Result<Vec<u8>>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
 {
     let name = match CString::new(name.as_ref().as_bytes()) {
         Ok(n) => n,
@@ -191,9 +187,9 @@ pub fn getxattr<P, S>(path: P, name: S) -> Result<Vec<u8>>
 ///
 /// For more information, see [lgetxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
 pub fn lgetxattr<P, S>(path: P, name: S) -> Result<Vec<u8>>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
 {
     let name = match CString::new(name.as_ref().as_bytes()) {
         Ok(n) => n,
@@ -239,8 +235,8 @@ pub fn lgetxattr<P, S>(path: P, name: S) -> Result<Vec<u8>>
 ///
 /// For more information, see [fgetxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
 pub fn fgetxattr<S>(fd: RawFd, name: S) -> Result<Vec<u8>>
-    where
-        S: AsRef<OsStr>,
+where
+    S: AsRef<OsStr>,
 {
     let name = match CString::new(name.as_ref().as_bytes()) {
         Ok(name) => name,
@@ -281,9 +277,9 @@ pub fn fgetxattr<S>(fd: RawFd, name: S) -> Result<Vec<u8>>
 ///
 /// For more information, see [removexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
 pub fn removexattr<P, S>(path: P, name: S) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -308,9 +304,9 @@ pub fn removexattr<P, S>(path: P, name: S) -> Result<()>
 ///
 /// For more information, see [lremovexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
 pub fn lremovexattr<P, S>(path: P, name: S) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -334,8 +330,8 @@ pub fn lremovexattr<P, S>(path: P, name: S) -> Result<()>
 ///
 /// For more information, see [fremovexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
 pub fn fremovexattr<S>(fd: RawFd, name: S) -> Result<()>
-    where
-        S: AsRef<OsStr>,
+where
+    S: AsRef<OsStr>,
 {
     let name = match CString::new(name.as_ref().as_bytes()) {
         Ok(name) => name,
@@ -355,10 +351,10 @@ pub fn fremovexattr<S>(fd: RawFd, name: S) -> Result<()>
 ///
 /// For more information, see [setxattr(2)](https://man7.org/linux/man-pages/man2/lsetxattr.2.html)
 pub fn setxattr<P, S, B>(path: P, name: S, value: B, flags: Flags) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
-        B: AsRef<[u8]>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
+    B: AsRef<[u8]>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -399,10 +395,10 @@ pub fn lsetxattr<P, S, B>(
     value: B,
     flags: Flags,
 ) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
-        B: AsRef<[u8]>,
+where
+    P: AsRef<Path>,
+    S: AsRef<OsStr>,
+    B: AsRef<[u8]>,
 {
     let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
         Ok(n) => n,
@@ -437,9 +433,9 @@ pub fn lsetxattr<P, S, B>(
 ///
 /// For more information, see [fsetxattr(2)](https://man7.org/linux/man-pages/man2/lsetxattr.2.html)
 pub fn fsetxattr<S, B>(fd: RawFd, name: S, value: B, flags: Flags) -> Result<()>
-    where
-        S: AsRef<OsStr>,
-        B: AsRef<[u8]>,
+where
+    S: AsRef<OsStr>,
+    B: AsRef<[u8]>,
 {
     let name = match CString::new(name.as_ref().as_bytes()) {
         Ok(name) => name,

--- a/src/platforms/netbsd.rs
+++ b/src/platforms/netbsd.rs
@@ -230,9 +230,9 @@ mod linux {
     ///
     /// For more information, see [getxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
     pub fn getxattr<P, S>(path: P, name: S) -> Result<Vec<u8>>
-        where
-            P: AsRef<Path>,
-            S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
     {
         let name = match CString::new(name.as_ref().as_bytes()) {
             Ok(n) => n,
@@ -283,9 +283,9 @@ mod linux {
     ///
     /// For more information, see [lgetxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
     pub fn lgetxattr<P, S>(path: P, name: S) -> Result<Vec<u8>>
-        where
-            P: AsRef<Path>,
-            S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
     {
         let name = match CString::new(name.as_ref().as_bytes()) {
             Ok(n) => n,
@@ -336,8 +336,8 @@ mod linux {
     ///
     /// For more information, see [fgetxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
     pub fn fgetxattr<S>(fd: RawFd, name: S) -> Result<Vec<u8>>
-        where
-            S: AsRef<OsStr>,
+    where
+        S: AsRef<OsStr>,
     {
         let name = match CString::new(name.as_ref().as_bytes()) {
             Ok(name) => name,
@@ -379,9 +379,9 @@ mod linux {
     ///
     /// For more information, see [removexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
     pub fn removexattr<P, S>(path: P, name: S) -> Result<()>
-        where
-            P: AsRef<Path>,
-            S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
     {
         let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
             Ok(n) => n,
@@ -408,9 +408,9 @@ mod linux {
     ///
     /// For more information, see [lremovexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
     pub fn lremovexattr<P, S>(path: P, name: S) -> Result<()>
-        where
-            P: AsRef<Path>,
-            S: AsRef<OsStr>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
     {
         let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
             Ok(n) => n,
@@ -436,8 +436,8 @@ mod linux {
     ///
     /// For more information, see [fremovexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
     pub fn fremovexattr<S>(fd: RawFd, name: S) -> Result<()>
-        where
-            S: AsRef<OsStr>,
+    where
+        S: AsRef<OsStr>,
     {
         let name = match CString::new(name.as_ref().as_bytes()) {
             Ok(name) => name,
@@ -462,10 +462,10 @@ mod linux {
         value: B,
         flags: Flags,
     ) -> Result<()>
-        where
-            P: AsRef<Path>,
-            S: AsRef<OsStr>,
-            B: AsRef<[u8]>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
+        B: AsRef<[u8]>,
     {
         let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
             Ok(n) => n,
@@ -506,10 +506,10 @@ mod linux {
         value: B,
         flags: Flags,
     ) -> Result<()>
-        where
-            P: AsRef<Path>,
-            S: AsRef<OsStr>,
-            B: AsRef<[u8]>,
+    where
+        P: AsRef<Path>,
+        S: AsRef<OsStr>,
+        B: AsRef<[u8]>,
     {
         let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
             Ok(n) => n,
@@ -549,9 +549,9 @@ mod linux {
         value: B,
         flags: Flags,
     ) -> Result<()>
-        where
-            S: AsRef<OsStr>,
-            B: AsRef<[u8]>,
+    where
+        S: AsRef<OsStr>,
+        B: AsRef<[u8]>,
     {
         let name = match CString::new(name.as_ref().as_bytes()) {
             Ok(name) => name,

--- a/src/platforms/netbsd.rs
+++ b/src/platforms/netbsd.rs
@@ -129,7 +129,7 @@ mod linux {
         let res = unsafe {
             super::bindings::listxattr(
                 path.as_ptr(),
-                buffer.as_ptr() as *mut libc::c_char,
+                buffer.as_mut_ptr().cast(),
                 buffer.capacity(),
             )
         };
@@ -171,7 +171,7 @@ mod linux {
         let res = unsafe {
             super::bindings::llistxattr(
                 path.as_ptr(),
-                buffer.as_ptr() as *mut libc::c_char,
+                buffer.as_mut_ptr().cast(),
                 buffer.capacity(),
             )
         };
@@ -206,7 +206,7 @@ mod linux {
         let res = unsafe {
             super::bindings::flistxattr(
                 fd,
-                buffer.as_ptr() as *mut libc::c_char,
+                buffer.as_mut_ptr().cast(),
                 buffer.capacity(),
             )
         };
@@ -230,9 +230,9 @@ mod linux {
     ///
     /// For more information, see [getxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
     pub fn getxattr<P, S>(path: P, name: S) -> Result<Vec<u8>>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+        where
+            P: AsRef<Path>,
+            S: AsRef<OsStr>,
     {
         let name = match CString::new(name.as_ref().as_bytes()) {
             Ok(n) => n,
@@ -263,7 +263,7 @@ mod linux {
             super::bindings::getxattr(
                 path.as_ptr(),
                 name.as_ptr(),
-                buffer.as_ptr() as *mut libc::c_void,
+                buffer.as_mut_ptr().cast(),
                 buffer_size as usize,
             )
         };
@@ -283,9 +283,9 @@ mod linux {
     ///
     /// For more information, see [lgetxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
     pub fn lgetxattr<P, S>(path: P, name: S) -> Result<Vec<u8>>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+        where
+            P: AsRef<Path>,
+            S: AsRef<OsStr>,
     {
         let name = match CString::new(name.as_ref().as_bytes()) {
             Ok(n) => n,
@@ -316,7 +316,7 @@ mod linux {
             super::bindings::lgetxattr(
                 path.as_ptr(),
                 name.as_ptr(),
-                buffer.as_ptr() as *mut libc::c_void,
+                buffer.as_mut_ptr().cast(),
                 buffer_size as usize,
             )
         };
@@ -336,8 +336,8 @@ mod linux {
     ///
     /// For more information, see [fgetxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
     pub fn fgetxattr<S>(fd: RawFd, name: S) -> Result<Vec<u8>>
-    where
-        S: AsRef<OsStr>,
+        where
+            S: AsRef<OsStr>,
     {
         let name = match CString::new(name.as_ref().as_bytes()) {
             Ok(name) => name,
@@ -359,7 +359,7 @@ mod linux {
             super::bindings::fgetxattr(
                 fd,
                 name.as_ptr(),
-                buffer.as_ptr() as *mut libc::c_void,
+                buffer.as_mut_ptr().cast(),
                 buffer_size as usize,
             )
         };
@@ -379,9 +379,9 @@ mod linux {
     ///
     /// For more information, see [removexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
     pub fn removexattr<P, S>(path: P, name: S) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+        where
+            P: AsRef<Path>,
+            S: AsRef<OsStr>,
     {
         let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
             Ok(n) => n,
@@ -408,9 +408,9 @@ mod linux {
     ///
     /// For more information, see [lremovexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
     pub fn lremovexattr<P, S>(path: P, name: S) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
+        where
+            P: AsRef<Path>,
+            S: AsRef<OsStr>,
     {
         let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
             Ok(n) => n,
@@ -436,8 +436,8 @@ mod linux {
     ///
     /// For more information, see [fremovexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
     pub fn fremovexattr<S>(fd: RawFd, name: S) -> Result<()>
-    where
-        S: AsRef<OsStr>,
+        where
+            S: AsRef<OsStr>,
     {
         let name = match CString::new(name.as_ref().as_bytes()) {
             Ok(name) => name,
@@ -462,10 +462,10 @@ mod linux {
         value: B,
         flags: Flags,
     ) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
-        B: AsRef<[u8]>,
+        where
+            P: AsRef<Path>,
+            S: AsRef<OsStr>,
+            B: AsRef<[u8]>,
     {
         let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
             Ok(n) => n,
@@ -476,7 +476,7 @@ mod linux {
             _ => return Err(Errno(libc::EINVAL)),
         };
 
-        let value_ptr = value.as_ref().as_ptr() as *mut libc::c_void;
+        let value_ptr = value.as_ref().as_ptr().cast();
         let value_len = value.as_ref().len();
 
         let res = unsafe {
@@ -506,10 +506,10 @@ mod linux {
         value: B,
         flags: Flags,
     ) -> Result<()>
-    where
-        P: AsRef<Path>,
-        S: AsRef<OsStr>,
-        B: AsRef<[u8]>,
+        where
+            P: AsRef<Path>,
+            S: AsRef<OsStr>,
+            B: AsRef<[u8]>,
     {
         let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
             Ok(n) => n,
@@ -520,7 +520,7 @@ mod linux {
             _ => return Err(Errno(libc::EINVAL)),
         };
 
-        let value_ptr = value.as_ref().as_ptr() as *mut libc::c_void;
+        let value_ptr = value.as_ref().as_ptr().cast();
         let value_len = value.as_ref().len();
 
         let res = unsafe {
@@ -549,16 +549,16 @@ mod linux {
         value: B,
         flags: Flags,
     ) -> Result<()>
-    where
-        S: AsRef<OsStr>,
-        B: AsRef<[u8]>,
+        where
+            S: AsRef<OsStr>,
+            B: AsRef<[u8]>,
     {
         let name = match CString::new(name.as_ref().as_bytes()) {
             Ok(name) => name,
             _ => return Err(Errno(libc::EINVAL)),
         };
 
-        let value_ptr = value.as_ref().as_ptr() as *mut libc::c_void;
+        let value_ptr = value.as_ref().as_ptr().cast();
         let value_len = value.as_ref().len();
 
         let res = unsafe {


### PR DESCRIPTION
#### What this PR does

1. Use `cast()` to cast pointer types, which is safer than `as`.
2. Avoid some unnecessary type casts.
3. Fix two bugs in the implementation of `extattr_get_xxx()`  on FreeBSD and NetBSD.