### PR TITLE
test: improve test for list_ex syscalls

### DIFF
--- a/src/platforms/darwin.rs
+++ b/src/platforms/darwin.rs
@@ -45,15 +45,15 @@ pub fn listxattr<P: AsRef<Path>>(
         {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            buffer_size => buffer_size,
+            buffer_size => buffer_size as usize,
         };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
     let res = unsafe {
         libc::listxattr(
             path.as_ptr(),
             buffer.as_mut_ptr().cast(),
-            buffer.capacity(),
+            buffer_size,
             options,
         )
     };
@@ -84,17 +84,12 @@ pub fn flistxattr(fd: RawFd, options: Options) -> Result<Vec<OsString>> {
         match unsafe { libc::flistxattr(fd, null_mut(), 0, options) } {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            buffer_size => buffer_size,
+            buffer_size => buffer_size as usize,
         };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
     let res = unsafe {
-        libc::flistxattr(
-            fd,
-            buffer.as_mut_ptr().cast(),
-            buffer.capacity(),
-            options,
-        )
+        libc::flistxattr(fd, buffer.as_mut_ptr().cast(), buffer_size, options)
     };
 
     match res {
@@ -148,17 +143,17 @@ where
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
-        buffer_size => buffer_size,
+        buffer_size => buffer_size as usize,
     };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::getxattr(
             path.as_ptr(),
             name.as_ptr(),
             buffer.as_mut_ptr().cast(),
-            buffer_size as usize,
+            buffer_size,
             position,
             options,
         )
@@ -197,17 +192,17 @@ pub fn fgetxattr<S: AsRef<OsStr>>(
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
-        buffer_size => buffer_size,
+        buffer_size => buffer_size as usize,
     };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::fgetxattr(
             fd,
             name.as_ptr(),
             buffer.as_mut_ptr().cast(),
-            buffer_size as usize,
+            buffer_size,
             position,
             options,
         )

--- a/src/platforms/freebsd.rs
+++ b/src/platforms/freebsd.rs
@@ -158,17 +158,17 @@ pub fn extattr_list_fd(
         match unsafe { libc::extattr_list_fd(fd, namespace, null_mut(), 0) } {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            size => size,
+            size => size as usize,
         };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::extattr_list_fd(
             fd,
             namespace,
             buffer.as_mut_ptr().cast(),
-            buffer_size as libc::size_t,
+            buffer_size,
         )
     };
 
@@ -204,17 +204,17 @@ where
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
-        size => size,
+        size => size as usize,
     };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::extattr_list_file(
             path.as_ptr(),
             namespace,
             buffer.as_mut_ptr().cast(),
-            buffer_size as libc::size_t,
+            buffer_size,
         )
     };
 
@@ -251,17 +251,17 @@ where
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
-        size => size,
+        size => size as usize,
     };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::extattr_list_link(
             path.as_ptr(),
             namespace,
             buffer.as_mut_ptr().cast(),
-            buffer_size as libc::size_t,
+            buffer_size,
         )
     };
 
@@ -295,9 +295,9 @@ pub fn extattr_get_fd<S: AsRef<OsStr>>(
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
-        size => size,
+        size => size as usize,
     };
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::extattr_get_fd(
@@ -305,7 +305,7 @@ pub fn extattr_get_fd<S: AsRef<OsStr>>(
             namespace,
             attrname.as_ptr(),
             buffer.as_mut_ptr().cast(),
-            0,
+            buffer_size,
         )
     };
 
@@ -353,9 +353,9 @@ where
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
-        size => size,
+        size => size as usize,
     };
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::extattr_get_file(
@@ -363,7 +363,7 @@ where
             namespace,
             attrname.as_ptr(),
             buffer.as_mut_ptr().cast(),
-            0,
+            buffer_size,
         )
     };
 
@@ -412,9 +412,9 @@ where
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
-        size => size,
+        size => size as usize,
     };
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::extattr_get_link(
@@ -422,7 +422,7 @@ where
             namespace,
             attrname.as_ptr(),
             buffer.as_mut_ptr().cast(),
-            0,
+            buffer_size,
         )
     };
 

--- a/src/platforms/linux_and_android.rs
+++ b/src/platforms/linux_and_android.rs
@@ -37,16 +37,12 @@ pub fn listxattr<P: AsRef<Path>>(path: P) -> Result<Vec<OsString>> {
         match unsafe { libc::listxattr(path.as_ptr(), null_mut(), 0) } {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            buffer_size => buffer_size,
+            buffer_size => buffer_size as usize,
         };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
     let res = unsafe {
-        libc::listxattr(
-            path.as_ptr(),
-            buffer.as_mut_ptr().cast(),
-            buffer.capacity(),
-        )
+        libc::listxattr(path.as_ptr(), buffer.as_mut_ptr().cast(), buffer_size)
     };
 
     match res {
@@ -78,16 +74,12 @@ pub fn llistxattr<P: AsRef<Path>>(path: P) -> Result<Vec<OsString>> {
         match unsafe { libc::llistxattr(path.as_ptr(), null_mut(), 0) } {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            buffer_size => buffer_size,
+            buffer_size => buffer_size as usize,
         };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
     let res = unsafe {
-        libc::llistxattr(
-            path.as_ptr(),
-            buffer.as_mut_ptr().cast(),
-            buffer.capacity(),
-        )
+        libc::llistxattr(path.as_ptr(), buffer.as_mut_ptr().cast(), buffer_size)
     };
 
     match res {
@@ -112,12 +104,12 @@ pub fn flistxattr(fd: RawFd) -> Result<Vec<OsString>> {
     let buffer_size = match unsafe { libc::flistxattr(fd, null_mut(), 0) } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
-        buffer_size => buffer_size,
+        buffer_size => buffer_size as usize,
     };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
     let res = unsafe {
-        libc::flistxattr(fd, buffer.as_mut_ptr().cast(), buffer.capacity())
+        libc::flistxattr(fd, buffer.as_mut_ptr().cast(), buffer_size)
     };
 
     match res {
@@ -158,17 +150,17 @@ where
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
-        buffer_size => buffer_size,
+        buffer_size => buffer_size as usize,
     };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::getxattr(
             path.as_ptr(),
             name.as_ptr(),
             buffer.as_mut_ptr().cast(),
-            buffer_size as usize,
+            buffer_size,
         )
     };
 
@@ -206,17 +198,17 @@ where
     } {
         -1 => return Err(errno()),
         0 => return Ok(Vec::new()),
-        buffer_size => buffer_size,
+        buffer_size => buffer_size as usize,
     };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::lgetxattr(
             path.as_ptr(),
             name.as_ptr(),
             buffer.as_mut_ptr().cast(),
-            buffer_size as usize,
+            buffer_size,
         )
     };
 
@@ -248,17 +240,17 @@ where
         match unsafe { libc::fgetxattr(fd, name.as_ptr(), null_mut(), 0) } {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            buffer_size => buffer_size,
+            buffer_size => buffer_size as usize,
         };
 
-    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
     let res = unsafe {
         libc::fgetxattr(
             fd,
             name.as_ptr(),
             buffer.as_mut_ptr().cast(),
-            buffer_size as usize,
+            buffer_size,
         )
     };
 

--- a/src/platforms/netbsd.rs
+++ b/src/platforms/netbsd.rs
@@ -122,15 +122,15 @@ mod linux {
         } {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            buffer_size => buffer_size,
+            buffer_size => buffer_size as usize,
         };
 
-        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
         let res = unsafe {
             super::bindings::listxattr(
                 path.as_ptr(),
                 buffer.as_mut_ptr().cast(),
-                buffer.capacity(),
+                buffer_size,
             )
         };
 
@@ -164,15 +164,15 @@ mod linux {
         } {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            buffer_size => buffer_size,
+            buffer_size => buffer_size as usize,
         };
 
-        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
         let res = unsafe {
             super::bindings::llistxattr(
                 path.as_ptr(),
                 buffer.as_mut_ptr().cast(),
-                buffer.capacity(),
+                buffer_size,
             )
         };
 
@@ -199,15 +199,15 @@ mod linux {
             match unsafe { super::bindings::flistxattr(fd, null_mut(), 0) } {
                 -1 => return Err(errno()),
                 0 => return Ok(Vec::new()),
-                buffer_size => buffer_size,
+                buffer_size => buffer_size as usize,
             };
 
-        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
         let res = unsafe {
             super::bindings::flistxattr(
                 fd,
                 buffer.as_mut_ptr().cast(),
-                buffer.capacity(),
+                buffer_size,
             )
         };
 
@@ -254,17 +254,17 @@ mod linux {
         } {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            buffer_size => buffer_size,
+            buffer_size => buffer_size as usize,
         };
 
-        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
         let res = unsafe {
             super::bindings::getxattr(
                 path.as_ptr(),
                 name.as_ptr(),
                 buffer.as_mut_ptr().cast(),
-                buffer_size as usize,
+                buffer_size,
             )
         };
 
@@ -307,17 +307,17 @@ mod linux {
         } {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            buffer_size => buffer_size,
+            buffer_size => buffer_size as usize,
         };
 
-        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
         let res = unsafe {
             super::bindings::lgetxattr(
                 path.as_ptr(),
                 name.as_ptr(),
                 buffer.as_mut_ptr().cast(),
-                buffer_size as usize,
+                buffer_size,
             )
         };
 
@@ -350,17 +350,17 @@ mod linux {
         } {
             -1 => return Err(errno()),
             0 => return Ok(Vec::new()),
-            buffer_size => buffer_size,
+            buffer_size => buffer_size as usize,
         };
 
-        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size);
 
         let res = unsafe {
             super::bindings::fgetxattr(
                 fd,
                 name.as_ptr(),
                 buffer.as_mut_ptr().cast(),
-                buffer_size as usize,
+                buffer_size,
             )
         };
 


### PR DESCRIPTION
Accidentally closed #9:(

-----

#### What this PR does:

In https://github.com/SteveLauC/extattr/pull/8, I found two fatal bugs (copy-paste typos) in the implementation of FreeBSD, which makes me doubt that my unit tests actually suck...

This PR makes tests stricter to avoid such stupid bugs...