### PR TITLE
ci: bump CI image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: stable x86_64-unknown-freebsd-14
   freebsd_instance:
-    image_family: freebsd-14-0-snap
+    image: freebsd-14-1-release-amd64-ufs
   sysinfo_script:
     - id
     - uname -a
@@ -18,28 +18,12 @@ task:
 task:
   name: stable x86_64-unknown-freebsd-13
   freebsd_instance:
-    image_family: freebsd-13-2
+    image_family: freebsd-13-3
   sysinfo_script:
     - id
     - uname -a
   setup_script:
     - pkg install -y curl
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y
-    - . $HOME/.cargo/env
-  test_script:
-    - . $HOME/.cargo/env
-    - cargo clippy --verbose
-    - cargo test --verbose
-
-task:
-  name: stable aarch64-apple-darwin
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-base:latest
-  sysinfo_script:
-    - id
-    - uname -a
-  setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y
     - . $HOME/.cargo/env

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,19 @@ env:
 
 jobs:
   x86_64-unknown-linux-gnu:
-
     runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Format check
+      run: cargo fmt --all -- --check
+    - name: Clippy
+      run: cargo clippy --verbose
+    - name: Run tests
+      run: cargo test --verbose
+
+  macOS-aarch64:
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this PR do

Bump CI image:

FreeBSD 13.2 -> FreeBSD 13.3
FreeBSD 14.0 -> FreeBSD 14.1
Migrate macOS CI to GHA
